### PR TITLE
Add fantasy novel draft

### DIFF
--- a/novel.md
+++ b/novel.md
@@ -1,0 +1,52 @@
+# The Shattered Herald
+
+## Prologue
+The night the Herald fell, the sky turned to fractured glass. Each shard of moonlight carried a whisper, and the whispers spelled the end of an age. The city of Caldrin slept beneath a silver dome, unaware of the storm coalescing above its rooftops.
+
+At the heart of Caldrin stood a spire of obsidian, a monument to treaties forged generations before. Upon that spire knelt Seris, last of the oathbound, palms pressed to the stone as though petitioning the ancient rock for mercy. In her hands burned the Ember—a living fragment of the world's first fire. The Ember's light pulsed against her gauntlets, each flare a heartbeat that wasn't hers.
+
+"The seal is weakening," Seris whispered. The words vanished in the wind. She had expected guardians, but the plaza lay empty. No soldiers, no priests, only the silent statues of forgotten kings staring down with sightless eyes.
+
+A crack split the dome overhead. Through it spilled a star that should have hung in the firmament. It fell like a teardrop and struck the spire just above Seris's bowed head. She didn't flinch. The star dissolved into tendrils of azure flame that swirled around her, seeking purchase. The Ember in her grasp flared in answer, repelling the invading fire.
+
+Seris closed her eyes and let the Ember's heat flood her veins. "If I fail, let the world remember I tried." She drove the shard of first fire into the obsidian. The world erupted.
+
+## Chapter One: Ash and Promise
+Kalen awoke to thunder that wasn't thunder. The boom rippled through his small attic room, shaking motes of dust from the beams. He rolled out of his straw mattress, grabbing the dagger he kept beneath his pillow, and crept to the round window.
+
+The sky above Caldrin churned with colors he had no names for. Ribbons of blue-white fire twisted together, a storm born of shattered stars. Far above, the silver dome that shielded the city shimmered, then split like an eggshell.
+
+"Not possible," Kalen breathed. The dome had stood for as long as any living soul remembered. It was the city's promise: Caldrin would be safe.
+
+Shouts rose from the streets. Merchants, couriers, and night watchmen pointed skyward, their faces washed in ghostly light. Kalen sheathed his dagger and bolted down the narrow stairwell. He needed to find his sister, Mara. She would be at the infirmary, tending to the sick. If the dome was failing, the infirmary would soon overflow.
+
+He burst onto the cobblestones. The air stung his lungs—ozone and something metallic. People swirled around him, a tide of panic. In the chaos, Kalen spotted a familiar figure: thick curls, stained apron, eyes sharp as flint.
+
+"Mara!" he shouted.
+
+She turned, relief flashing across her face before worry overtook it. "You're supposed to be on a supply run. What happened?"
+
+"The sky," Kalen said, pointing. "The dome—"
+
+A second boom cut him off. The silver shell overhead tore open, revealing a spiral of darkness beyond. From that void descended a line of fire, striking the obsidian spire at the city's center. A wave of heat rolled outward, knocking Kalen to his knees.
+
+When he looked up, he saw her: a woman cloaked in ash, standing atop the spire as if she were born of smoke. In her hand blazed a shard of living flame. Even from a distance, Kalen felt its heat.
+
+"Is that—" Mara began.
+
+"A Herald," Kalen whispered, though none had been seen in centuries.
+
+The Herald raised the burning shard. A ring of light expanded from the spire, sweeping across the city like a tide. Where it passed, the clamor stilled. People froze mid-cry, eyes wide, as if time itself had hesitated.
+
+Kalen felt the wave approach. It washed over him, warm as a hearthfire. For a heartbeat, he saw something—fields of crystal, skies of mirrored glass, and beyond them, a shadow with too many wings. Then the vision shattered, and sound returned in a crash of screams.
+
+Mara grabbed his arm. "We have to move!" She pulled him toward the infirmary.
+
+As they ran, Kalen looked back once more at the spire. The Herald remained, but the Ember in her hand flickered, dimming against the darkening sky.
+
+## Outline
+1. **Inciting Incident**: The city's protective dome shatters as the Herald attempts to repair an ancient seal, unleashing energy that awakens dormant forces.
+2. **Rising Action**: Kalen and Mara discover the Ember's power is linked to forgotten bonds between humanity and elemental spirits. Political factions vie to control the shard.
+3. **Midpoint Revelation**: Seris, the Herald, survives but is hunted by shadowed beings known as the Veilborn. She entrusts Kalen with a fragment of the Ember, binding his fate to hers.
+4. **Climax**: The heroes journey beyond Caldrin into the Glass Wastes, confronting the entity that cracked the dome—a being of living darkness seeking to reclaim the first fire.
+5. **Resolution**: Kalen wields the Ember to reignite the shattered seal, but at the cost of his own mortality. The dome is remade, yet the world knows the Heralds have returned—and with them, war.


### PR DESCRIPTION
## Summary
- Add original fantasy novel draft "The Shattered Herald" with a prologue, opening chapter, and story outline

## Testing
- `python -m pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_68b25a085330832881959261b8c41560